### PR TITLE
Syntax errors fixed for Windows

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -72,7 +72,7 @@ let frac = '.' digit* (* a decimal point followed by zero or more digits*)
 let float = digit* frac (* matches zero or more digits before the decimal point*)
 
 let whitespace = [' ' '\t' '|']+ (*| is to use in the sequences, to separate bars *)
-let newline = '\n' | '\r'
+let newline = "\r\n" | '\n' | '\r'
 let letter = ['a'-'z' 'A'-'Z']+
 let ident = letter (letter | '-' | digit)* (* identity for a sequence *)
 

--- a/tests/fail/test000.C64MC
+++ b/tests/fail/test000.C64MC
@@ -1,5 +1,5 @@
 /* Parameters are defined in the wrong order */
-/* Parser.MenhirBasics error is raised */
+/* Raises "Parsing error: Syntax error on line 5, character 1-13" */
 
 tempo = 120
 standardPitch = 440

--- a/tests/fail/test001.C64MC
+++ b/tests/fail/test001.C64MC
@@ -1,5 +1,5 @@
 /* Parameter names are misspelled */
-/* Parser.MenhirBasics error is raised */
+/* Raises "Parsing Error: Syntax error at line 4, character 1-5" */
 
 Tempo = 120
 timeSig = (4,4)

--- a/tests/fail/test002.C64MC
+++ b/tests/fail/test002.C64MC
@@ -1,5 +1,5 @@
 /* Parameter (standardPitch) is missing */
-/* Parser.MenhirBasics error is raised */
+/* Parsing Error: Syntax error at line 7, character 1-8 */
 
 tempo = 120
 timeSignature = (4,4)

--- a/tests/fail/test004.C64MC
+++ b/tests/fail/test004.C64MC
@@ -1,5 +1,5 @@
 /* Missing delimiters for sequences */
-/* Parser.MenhirBasics error is raised */
+/* Parsing Error: Syntax error at line 9, character 1-8 */
 
 tempo = 120
 timeSignature = (4,4)

--- a/tests/fail/test005.C64MC
+++ b/tests/fail/test005.C64MC
@@ -1,5 +1,5 @@
 /* Empty sequence is defined. Will raise an error even if sequence is not used */
-/* Parser.MenhirBasics error is raised */
+/* Parsing Error: Syntax error at line 11, character 19-19 */
 
 tempo = 120
 timeSignature = (4,4)

--- a/tests/fail/test009.C64MC
+++ b/tests/fail/test009.C64MC
@@ -1,5 +1,5 @@
 /* Missing fraction on first note. */
-/* Parser.MenhirBasics error is raised */
+/* Parsing Error: Syntax error at line 8, character 21-21 */
 
 tempo = 120
 timeSignature = (4,4)

--- a/tests/fail/test010.C64MC
+++ b/tests/fail/test010.C64MC
@@ -1,5 +1,5 @@
 /* Negative octave value. Shows that generally, negative values are treated as just invalid tokens */
-/* Lexical error is raised */
+/* Raises "Lexing Error: Lexical error at line 8, character 23-23, expected a token" */
 
 tempo = 120
 timeSignature = (4,4)


### PR DESCRIPTION
Added "\r\n" to lexer newline so windows will register the correct line number for syntax errors. Also added the outcome of each failed test